### PR TITLE
fix: local env file not read

### DIFF
--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -10,7 +10,7 @@ import {
     TouchableOpacity
 } from "react-native";
 import { useEffect } from "react";
-import { API_URL } from "@env"
+import { API_URL } from "@env";
 
 interface User {
     email: string;

--- a/screens/SignUpScreen.tsx
+++ b/screens/SignUpScreen.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import axios from "axios";
-import { API_URL } from "@env"
+import { API_URL } from "@env";
 
 import {
     StyleSheet,


### PR DESCRIPTION
Summary:
Fixed an error for local env file reference. 


Because of the missing semicolon, both the sign-up and sign-in page could not read the local env file properly, leading to 404 errors, and unhandled Rejection (TypeError)